### PR TITLE
fix: use prerelease constraint

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -8,7 +8,7 @@ export default defineNuxtModule<ModuleOptions>({
   meta: {
     name: 'nuxt-typed-router',
     configKey: 'nuxtTypedRouter',
-    compatibility: { nuxt: '^3.0.0', bridge: false },
+    compatibility: { nuxt: '^3.0.0-rc.1', bridge: false },
   },
   setup(moduleOptions, nuxt) {
     const srcDir = nuxt.options.srcDir;


### PR DESCRIPTION
In https://github.com/nuxt/framework/pull/7116 we made a breaking change allowing modules to use RC constraints. This PR fixes this.