### PR TITLE
PR commit

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -1,5 +1,4 @@
-import { fileURLToPath } from 'url';
-import { defineNuxtModule } from '@nuxt/kit';
+import { defineNuxtModule, createResolver } from '@nuxt/kit';
 import { Nuxt } from '@nuxt/schema';
 import { createTypedRouter } from './core';
 import type { ModuleOptions } from './types';
@@ -18,12 +17,10 @@ export default defineNuxtModule<ModuleOptions>({
   setup(moduleOptions, nuxt: Nuxt) {
     const srcDir = nuxt.options.srcDir;
     const { plugin } = moduleOptions as Required<ModuleOptions>;
+    const { resolve } = createResolver(import.meta.url);
     nuxt.options.alias = {
       ...nuxt.options.alias,
-      '@typed-router': fileURLToPath(
-        // @ts-ignore
-        new URL(`${nuxt.options.rootDir}/.nuxt/typed-router`, import.meta.url)
-      ),
+      '@typed-router': resolve(`${nuxt.options.rootDir}/.nuxt/typed-router`),
     };
 
     nuxt.hook('pages:extend', () => createTypedRouter({ srcDir, nuxt, plugin }));


### PR DESCRIPTION
fixes #57:
fileUrlToPath only works for files, not for folders, which does not work when it's trying to create an alias for a folder.

i used `createResolver` from `@nuxt/kit` (recommended by Nuxt / NuxtKit)
(see https://nuxt.com/docs/guide/going-further/modules#provide-nuxt-plugins)