### PR TITLE
fix: nuxt components not being typed

### DIFF
--- a/src/core/output/generators/files/__typed-router.d.file.ts
+++ b/src/core/output/generators/files/__typed-router.d.file.ts
@@ -64,8 +64,8 @@ export function createTypedRouterDefinitionFile(): string {
       {}
     >;
     
-    declare module '@vue/runtime-core' {
-      export interface GlobalComponents {
+    declare module 'vue' {
+      interface GlobalComponents {
         NuxtLink: TypedNuxtLink;
       }
     }


### PR DESCRIPTION
First of all, thank you for this module. It's really well thought out and a pleasant experience! 
This PR addresses an issue with Volar. If you use both `vue` and `@vue/runtime-core,` Nuxt components lose their type. 
For more context, please see Danielroe's comments on this PR https://github.com/formkit/formkit/pull/581