### PR TITLE
Update dependency on Prettier to version 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "mkdirp": "^3.0.1",
     "nanoid": "^4.0.2",
     "pathe": "1.1.0",
-    "prettier": "2.8.8"
+    "prettier": "3.0.0"
   },
   "devDependencies": {
     "@nuxt/devtools": "^0.5.5",


### PR DESCRIPTION
This Pull Request updates the dependency on `prettier` to version 3.0.0.

I encountered an issue when using `nuxt-typed-router` with `prettier` version 3.0.0. I found that `nuxt-typed-router` depends on `prettier` version 2.8.8, which caused conflicts with my project's dependencies.

I was able to temporarily resolve the issue by manually updating the `prettier` version in the `nuxt-typed-router` package to 3.0.0, and everything worked as expected.

This Pull Request updates the dependency on `prettier` to version 3.0.0 in the `nuxt-typed-router` package to prevent this issue from happening in the future.

Thank you.
