### PR TITLE
feat: add support for nuxt link locale from i18n

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@nuxt/test-utils": "3.8.1",
     "@nuxt/types": "2.17.2",
     "@nuxtjs/eslint-config-typescript": "12.1.0",
-    "@nuxtjs/i18n": "8.0.0-beta.10",
+    "@nuxtjs/i18n": "8.0.0-rc.5",
     "@nuxtjs/web-vitals": "0.2.6",
     "@types/lodash-es": "4.17.11",
     "@types/node": "20.9.0",

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -3,7 +3,7 @@ import NuxtTypedRouter from '..';
 
 export default defineNuxtConfig({
   extends: ['nuxt-seo-kit'],
-  modules: [NuxtTypedRouter, '@nuxtjs/i18n'],
+  modules: [ '@nuxtjs/i18n', NuxtTypedRouter],
   devtools: {
     enabled: true,
   },

--- a/src/core/config/moduleOptions.ts
+++ b/src/core/config/moduleOptions.ts
@@ -24,6 +24,7 @@ class ModuleOptionsStore {
   i18nOptions: NuxtI18nOptions | null = null;
   i18nLocales: string[] = [];
   experimentalIgnoreRoutes: string[] = [];
+  nuxtLinkLocaleExists: boolean = false;
 
   updateOptions(options: ModuleOptions & CustomNuxtConfigOptions) {
     if (options.plugin != null) this.plugin = options.plugin;

--- a/src/core/output/generators/files/__i18n-router.file.ts
+++ b/src/core/output/generators/files/__i18n-router.file.ts
@@ -2,20 +2,25 @@ import { returnIfTrue } from '../../../../utils';
 import { moduleOptionStore } from '../../../config';
 
 export function createi18nRouterFile() {
-  const { router } = moduleOptionStore.getResolvedStrictOptions();
-  const { i18nOptions, pathCheck, i18nLocales } = moduleOptionStore;
+  const { router, NuxtLink } = moduleOptionStore.getResolvedStrictOptions();
+  const { i18nOptions, pathCheck, i18nLocales, nuxtLinkLocaleExists: nLLE } = moduleOptionStore;
 
   const LocalePathType =
     i18nOptions?.strategy === 'no_prefix' ? 'TypedPathParameter' : 'TypedLocalePathParameter';
 
   return /* typescript */ `
-  import type { RouteLocationRaw } from 'vue-router';
+  import type { RouteLocationRaw${returnIfTrue(nLLE, `, RouteLocationPathRaw`)} } from 'vue-router';
   import { useLocalePath as _useLocalePath, useLocaleRoute as _useLocaleRoute} from 'vue-i18n-routing';
   import type {TypedRouteLocationRawFromName, TypedLocationAsRelativeRaw, TypedRouteFromName} from './__router';
-  import type {RoutesNamesList} from './__routes';
+  import type { RoutesNamesList${returnIfTrue(nLLE,`, RoutesNamedLocations`)} } from './__routes';
   ${returnIfTrue(
     pathCheck,
     `import type {TypedLocalePathParameter, TypedPathParameter, RouteNameFromLocalePath} from './__paths';`
+  )}
+  ${returnIfTrue(
+    nLLE,
+    `import NuxtLink from "nuxt/dist/app/components/nuxt-link";
+  import type { NuxtLinkProps } from "#imports";`,
   )}
 
   export type I18nLocales = ${
@@ -41,7 +46,7 @@ export function createi18nRouterFile() {
   export function useLocalePath(options?: Pick<NonNullable<Parameters<typeof _useLocalePath>[0]>, 'i18n'>): TypedToLocalePath {
      return _useLocalePath(options) as any;
   }
-  
+
   export interface TypedLocaleRoute {
     <T extends RoutesNamesList, P extends string>(to: TypedRouteLocationRawFromName<T, P>, locale?: I18nLocales | undefined) : TypedRouteFromName<T>
     ${returnIfTrue(
@@ -54,6 +59,45 @@ export function createi18nRouterFile() {
   export function useLocaleRoute(options?: Pick<NonNullable<Parameters<typeof _useLocaleRoute>[0]>, 'i18n'>): TypedLocaleRoute {
     return _useLocaleRoute(options) as any;
   }
+  ${returnIfTrue(
+    nLLE,
+    `
+  type TypedNuxtLinkLocaleProps<T extends string, E extends boolean = false> = Omit<NuxtLinkProps, 'to' | 'external'> &
+   {
+    to: 
+      | Omit<Exclude<RouteLocationRaw, string>, 'name' | 'params'> & RoutesNamedLocations
+      | Omit<RouteLocationPathRaw, 'path'>
+      ${returnIfTrue(
+        pathCheck && !NuxtLink.strictRouteLocation,
+        `& {path?: (E extends true ? string : ${LocalePathType}<T>)}`,
+      )}
+      ${returnIfTrue(!pathCheck && !NuxtLink.strictToArgument, ` | string`)}
+      ${returnIfTrue(
+        pathCheck && NuxtLink.strictToArgument,
+        ` | (E extends true ? string : void)`,
+      )}
+      ${returnIfTrue(
+        pathCheck && !NuxtLink.strictToArgument,
+        ` | (E extends true ? string : ${LocalePathType}<T>)`,
+      )},
+    external?: E
+    }
+
+
+     
+  export type TypedNuxtLinkLocale = new <P extends string, E extends boolean = false>(props: TypedNuxtLinkLocaleProps<P, E>) => Omit<
+    typeof NuxtLink,
+    '$props'
+  > & {
+    $props: TypedNuxtLinkLocaleProps<P, E>;
+  };
+  
+  // Declare runtime-core instead of vue for compatibility issues with pnpm
+  declare module 'vue' {
+    interface GlobalComponents {
+      NuxtLinkLocale: TypedNuxtLinkLocale;
+    }
+  }`)}
 
   `;
 }

--- a/src/core/output/generators/files/__i18n-router.file.ts
+++ b/src/core/output/generators/files/__i18n-router.file.ts
@@ -81,7 +81,7 @@ export function createi18nRouterFile() {
         ` | (E extends true ? string : ${LocalePathType}<T>)`,
       )},
     external?: E,
-    locale?: I18nLocales
+    locale?: E extends true ? undefined : I18nLocales
     }
 
 

--- a/src/core/output/generators/files/__i18n-router.file.ts
+++ b/src/core/output/generators/files/__i18n-router.file.ts
@@ -20,7 +20,7 @@ export function createi18nRouterFile() {
   ${returnIfTrue(
     nLLE,
     `import NuxtLink from "nuxt/dist/app/components/nuxt-link";
-  import type { NuxtLinkProps } from "#imports";`,
+  import type { NuxtLinkProps } from "#app";`,
   )}
 
   export type I18nLocales = ${
@@ -80,7 +80,8 @@ export function createi18nRouterFile() {
         pathCheck && !NuxtLink.strictToArgument,
         ` | (E extends true ? string : ${LocalePathType}<T>)`,
       )},
-    external?: E
+    external?: E,
+    locale?: I18nLocales
     }
 
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -80,6 +80,12 @@ export default defineNuxtModule<ModuleOptions>({
       }
     });
 
+    nuxt.hook("components:extend", (components) => {
+      moduleOptionStore.nuxtLinkLocaleExists = !!components.find(
+        (c) => c.pascalName === "NuxtLinkLocale",
+      );
+    });
+
     if (nuxt.options.dev) {
       nuxt.hook('devtools:customTabs' as any, (tabs: any[]) => {
         tabs.push({

--- a/test/fixtures/complex/nuxt.config.ts
+++ b/test/fixtures/complex/nuxt.config.ts
@@ -1,7 +1,7 @@
 import TestModuleRoute from './src/modules/testAddRoute';
 
 export default defineNuxtConfig({
-  modules: ['nuxt-typed-router', TestModuleRoute, '@nuxtjs/i18n'],
+  modules: [ TestModuleRoute, '@nuxtjs/i18n', 'nuxt-typed-router'],
   nuxtTypedRouter: {
     plugin: true,
     experimentalIgnoreRoutes: ['[...404].vue'],

--- a/test/fixtures/complex/package.json
+++ b/test/fixtures/complex/package.json
@@ -9,7 +9,7 @@
     "preview": "nuxt preview"
   },
   "devDependencies": {
-    "@nuxtjs/i18n": "8.0.0-beta.9",
+    "@nuxtjs/i18n": "8.0.0-rc.5",
     "nuxt": "3.8.1",
     "nuxt-typed-router": "workspace:*"
   }

--- a/test/fixtures/complex/tests/i18n/NuxtLinkLocale.spec-d.ts
+++ b/test/fixtures/complex/tests/i18n/NuxtLinkLocale.spec-d.ts
@@ -1,0 +1,141 @@
+import { assertType, vi } from 'vitest';
+import type { GlobalComponents } from 'vue';
+
+const NuxtLinkLocale: GlobalComponents['NuxtLinkLocale'] = vi.fn() as any;
+
+// ! ------ Should Error ❌
+
+// *  index.vue
+// @ts-expect-error
+assertType(new NuxtLinkLocale({ to: { name: 'index', params: { id: 1 } } }));
+// @ts-expect-error
+assertType(new NuxtLinkLocale({ to: { name: 'index', params: { id: 1 } } }));
+// @ts-expect-error
+assertType(new NuxtLinkLocale({ to: { name: 'blabla-baguette' } }));
+
+// * --- [id].vue
+// @ts-expect-error
+assertType(new NuxtLinkLocale({ to: { name: 'user-id' } }));
+// @ts-expect-error
+assertType(new NuxtLinkLocale({ to: { name: 'user-id', params: { foo: 'bar' } } }));
+
+// * --- [foo]-[[bar]].vue
+// @ts-expect-error
+assertType(new NuxtLinkLocale({ to: { name: 'user-foo-bar' } }));
+// @ts-expect-error
+assertType(new NuxtLinkLocale({ to: { name: 'user-foo-bar', params: { bar: 1 } } }));
+
+// * --- [...slug].vue
+// @ts-expect-error
+assertType(new NuxtLinkLocale({ to: { name: 'user-slug' } }));
+// @ts-expect-error
+assertType(new NuxtLinkLocale({ to: { name: 'user-slug', params: { slug: 1 } } }));
+
+// * --- [one]-foo-[two].vue
+// @ts-expect-error
+assertType(new NuxtLinkLocale({ to: { name: 'user-one-foo-two' } }));
+// @ts-expect-error
+assertType(new NuxtLinkLocale({ to: { name: 'user-one-foo-two', params: { one: 1 } } }));
+
+// * --- [id]/[slug].vue
+// @ts-expect-error
+assertType(new NuxtLinkLocale({ to: { name: 'user-id-slug' } }));
+// @ts-expect-error
+assertType(new NuxtLinkLocale({ to: { name: 'user-id-slug', params: { id: 1 } } }));
+
+// * --- Routes added by modules
+// @ts-expect-error
+assertType(new NuxtLinkLocale({ to: { name: 'test-module' } }));
+
+// --- Path navigation
+
+// ! ------ Should Error ❌
+
+// @ts-expect-error
+assertType(new NuxtLinkLocale({ to: '' }));
+// @ts-expect-error
+assertType(new NuxtLinkLocale({ to: '/admin ' }));
+// @ts-expect-error
+assertType(new NuxtLinkLocale({ to: '/admin/ /' }));
+// @ts-expect-error
+assertType(new NuxtLinkLocale({ to: `/ / // / / eefzr` }));
+// @ts-expect-error
+assertType(new NuxtLinkLocale({ to: '/elzhlzehflzhef' }));
+// @ts-expect-error
+assertType(new NuxtLinkLocale({ to: '/admin/foo/bar' }));
+// @ts-expect-error
+assertType(new NuxtLinkLocale({ to: '/admin/foo/bar/baz' }));
+// @ts-expect-error
+assertType(new NuxtLinkLocale({ to: `/admin/${id}/action-bar/taz?query` }));
+// @ts-expect-error
+assertType(new NuxtLinkLocale({ to: '/admin/panel/3O9393/bar' }));
+// @ts-expect-error
+assertType(new NuxtLinkLocale({ to: '/admin/foo/ profile/ezfje' }));
+// @ts-expect-error
+assertType(new NuxtLinkLocale({ to: '/admin/3U93U/settings/baz' }));
+// @ts-expect-error
+assertType(new NuxtLinkLocale({ to: '/admin/panel/?fjzk' }));
+
+// $ ----- Should be valid ✅
+
+const id = '38789803';
+assertType(new NuxtLinkLocale({ to: '/' }));
+assertType(new NuxtLinkLocale({ to: '/baguette' }));
+assertType(new NuxtLinkLocale({ to: '/admin/foo' }));
+assertType(new NuxtLinkLocale({ to: '/admin/foo/' }));
+assertType(new NuxtLinkLocale({ to: `/admin/${id}/action-bar#hash` }));
+assertType(new NuxtLinkLocale({ to: `/admin/${id}/action-bar?query=bar` }));
+assertType(new NuxtLinkLocale({ to: '/admin/foo/profile/' }));
+assertType(new NuxtLinkLocale({ to: `/admin/${id}/settings` }));
+assertType(new NuxtLinkLocale({ to: '/admin/panel/' }));
+assertType(new NuxtLinkLocale({ to: '/admin/panel/938783/' }));
+assertType(new NuxtLinkLocale({ to: '/user/38873-' }));
+assertType(new NuxtLinkLocale({ to: '/user/38673/bar/#hash' }));
+assertType(new NuxtLinkLocale({ to: '/user/ç9737/foo/articles?baz=foo' }));
+assertType(new NuxtLinkLocale({ to: '/user/catch/1/2' }));
+assertType(new NuxtLinkLocale({ to: '/user/test-' }));
+assertType(new NuxtLinkLocale({ to: '/user' }));
+
+// $ ----- Should be valid ✅
+
+assertType(new NuxtLinkLocale({ to: { name: 'index' } }));
+assertType(new NuxtLinkLocale({ to: { name: 'user-id', params: { id: 1 }, hash: 'baz' } }));
+assertType(new NuxtLinkLocale({ to: { name: 'user-foo-bar', params: { foo: 'bar' }, force: true } }));
+assertType(
+  new NuxtLinkLocale({
+    to: { name: 'user-foo-bar', params: { foo: 'bar', bar: 'baz' } },
+  })
+);
+assertType(new NuxtLinkLocale({ to: { name: 'user-catch-slug', params: { slug: ['foo'] } } }));
+assertType(new NuxtLinkLocale({ to: { name: 'user-catch-slug', params: { slug: [1, 2, 3] } } }));
+assertType(new NuxtLinkLocale({ to: { name: 'user-one-foo-two', params: { one: 1, two: '2' } } }));
+assertType(
+  new NuxtLinkLocale({
+    to: { name: 'user-id-slug', params: { slug: '2' }, query: { foo: 'bar' } },
+  })
+);
+
+assertType(
+  new NuxtLinkLocale({
+    to: { name: 'test-module', params: { foo: 1 }, query: { foo: 'bar' } },
+  })
+);
+
+// - With External prop
+
+// $ ----- Should be valid ✅
+
+assertType(new NuxtLinkLocale({ to: '/admin/:id/', external: false }));
+assertType(new NuxtLinkLocale({ to: 'http://google.com', external: true }));
+
+// - With Locale prop
+
+// $ ----- Should be valid ✅
+
+assertType(new NuxtLinkLocale({ to: '/admin/:id/', locale: 'en' }));
+assertType(new NuxtLinkLocale({ to: '/admin/:id/', locale: 'fr' }));
+
+// ! ------ Should Error ❌
+
+// @ts-expect-error
+assertType(new NuxtLinkLocale({ to: '/admin/:id/', external: false, locale: 'en' }));


### PR DESCRIPTION
For the types for the [NuxtLinkLocale](https://github.com/nuxt-modules/i18n/blob/main/src/runtime/components/NuxtLinkLocale.ts) component to be generated correctly this module needs to be loaded after the i18n module. This is because of how we detect if this component exists in th first place. (see module.ts file)

I did try the following to avoid this:
- could **not** import component directly because the exports are locked down by the [package.json](https://github.com/nuxt-modules/i18n/blob/main/package.json#L25-L32) file of the i18n repo (node complains at runtime) and the allowed files do not export the component (I don't know if there is a workaround)
- could **not** use the \#components file because it is not generated yet
- could **not** use the \#components file in the file that we generate to conditionally set the type to undefined because of how import/declare order goes around

Conditional generation and/or declaration of the types is required because this component was introduced on July 31. in the [v8.0.0-rc.1](https://github.com/nuxt-modules/i18n/releases/tag/v8.0.0-rc.1) relase. If it is fine to include the types by default then all of the above can be safely ignored and changes can be made accordingly.