### PR TITLE
docs(use-route): correct variable name

### DIFF
--- a/docs/content/2.usage/2.useRoute.md
+++ b/docs/content/2.usage/2.useRoute.md
@@ -16,7 +16,7 @@ If you have a `[foo].vue` page file, you can safely check the route name with th
 const route = useRoute();
 
 if (route.name === 'foo') {
-  console.log(router.params.foo) // types-check
+  console.log(route.params.foo) // types-check
 }
 </script>
 ```
@@ -30,8 +30,8 @@ But if you have a `[foo]-[[bar]].vue` page file, the `bar` param will be correct
 const route = useRoute();
 
 if (route.name === 'foo-bar') {
-  console.log(router.params.foo) // string
-  console.log(router.params.bar) // string | undefined
+  console.log(route.params.foo) // string
+  console.log(route.params.bar) // string | undefined
 }
 </script>
 ```


### PR DESCRIPTION
There is no `router`.