### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,11 +63,7 @@ Demo repo 🧪 : [nuxt-typed-router-demo](https://github.com/victorgarciaesgi/nu
 ### For Nuxt 3
 
 ```bash
-yarn add -D nuxt-typed-router
-# or
-npm install -D nuxt-typed-router
-# or
-pnpm install -D nuxt-typed-router
+npx nuxi@latest module add typed-router
 ```
 
 

--- a/docs/content/0.index.md
+++ b/docs/content/0.index.md
@@ -13,7 +13,7 @@ cta:
 secondary:
   - Open on GitHub →
   - https://github.com/victorgarciaesgi/nuxt-typed-router
-snippet: npm install nuxt-typed-router
+snippet: npx nuxi@latest module add typed-router
 ---
 
 #title

--- a/docs/content/1.guide/0.index.md
+++ b/docs/content/1.guide/0.index.md
@@ -1,18 +1,8 @@
 
 # Installation
-
-
-::code-group
-```bash [yarn]
-yarn add nuxt-typed-router
+```bash
+npx nuxi@latest module add typed-router
 ```
-```bash [pnpm]
-pnpm install nuxt-typed-router
-```
-```bash [npm]
-npm install nuxt-typed-router
-```
-::
 
 Add the module to `modules` in your `nuxt.config`:
 


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
