### PR TITLE
fix(types): update module augmentation

### DIFF
--- a/src/core/output/generators/files/__typed-router.d.file.ts
+++ b/src/core/output/generators/files/__typed-router.d.file.ts
@@ -66,7 +66,21 @@ export function createTypedRouterDefinitionFile(): string {
     > & {
       $props: TypedNuxtLinkProps<T, P, E>;
     };
-    
+
+    declare module '@vue/runtime-core' {
+      interface GlobalComponents {
+        NuxtLink: TypedNuxtLink;
+        ${returnIfTrue(i18n, ` NuxtLinkLocale: TypedNuxtLinkLocale;`)}
+      }
+    }
+
+    declare module '@vue/runtime-dom' {
+      interface GlobalComponents {
+        NuxtLink: TypedNuxtLink;
+        ${returnIfTrue(i18n, ` NuxtLinkLocale: TypedNuxtLinkLocale;`)}
+      }
+    }
+
     declare module 'vue' {
       interface GlobalComponents {
         NuxtLink: TypedNuxtLink;


### PR DESCRIPTION
Since https://github.com/nuxt/nuxt/pull/26541 multiple modules need to be augmented for type checking to continue working as expected.

The mentioned PR is included in Nuxt starting with version `3.11.2`.