### PR TITLE
fix routes-paths-block

### DIFF
--- a/src/core/output/generators/blocks/routes/routes-paths.block.ts
+++ b/src/core/output/generators/blocks/routes/routes-paths.block.ts
@@ -75,9 +75,9 @@ export function createValidatePathTypes(
                    ? pathConditions
                        .filter((f) => routesList.includes(f.routeName))
                        .map((t) => `${t.typeName}<T> extends true ? "${t.routeName}"`)
-                       .join(': ')
+                       .join(': ') + ": never"
                    : 'any'
-               } : never`
+      }`
              : ': never'
          } 
        : never; 


### PR DESCRIPTION
Fixes https://github.com/victorgarciaesgi/nuxt-typed-router/issues/142
Should also fix https://github.com/victorgarciaesgi/nuxt-typed-router/issues/135

The ": never" is only needed at the end of the joined array.
