### PR TITLE
fix(module): properly extend `vueCompilerOptions`

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -70,10 +70,9 @@ export default defineNuxtModule<ModuleOptions>({
     nuxt.hook('prepare:types', (options) => {
       options.tsConfig.include?.unshift('./typed-router/typed-router.d.ts');
       if (moduleOptions.pathCheck) {
-        (options.tsConfig as any).vueCompilerOptions = {
-          jsxTemplates: true,
-          experimentalRfc436: true,
-        };
+        (options.tsConfig as any).vueCompilerOptions = (options.tsConfig as any).vueCompilerOptions || {};
+        options.tsConfig.vueCompilerOptions.jsxTemplates = true;
+        options.tsConfig.vueCompilerOptions.experimentalRfc436 = true;
       }
       if (moduleOptions.removeNuxtDefs) {
         removeNuxtDefinitions({


### PR DESCRIPTION
The current implementation just sets `vueCompilerOptions`, potentially overriding a user defined `vueCompilerOptions`. With this change, only two values are set, while other potentially already existing values can be kept.