### PR TITLE
fix(module): remove vue compiler options

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -69,12 +69,6 @@ export default defineNuxtModule<ModuleOptions>({
     // Force register of type declaration
     nuxt.hook('prepare:types', (options) => {
       options.tsConfig.include?.unshift('./typed-router/typed-router.d.ts');
-      if (moduleOptions.pathCheck) {
-        (options.tsConfig as any).vueCompilerOptions = {
-          jsxTemplates: true,
-          experimentalRfc436: true,
-        };
-      }
       if (moduleOptions.removeNuxtDefs) {
         removeNuxtDefinitions({
           autoImport: nuxt.options.imports.autoImport ?? true,


### PR DESCRIPTION
As discussed in https://github.com/victorgarciaesgi/nuxt-typed-router/pull/151#issuecomment-2176142124: I think `pathCheck` should stay as it's used in other places as well. Also, I think this change should trigger a path-level release as it should not be breaking, right?