### PR TITLE
fix(i18n): ignore i18n modifiers

### DIFF
--- a/src/core/config/moduleOptions.ts
+++ b/src/core/config/moduleOptions.ts
@@ -26,6 +26,7 @@ class ModuleOptionsStore {
   i18nOptions: NuxtI18nOptions | null = null;
   i18nLocales: string[] = [];
   ignoreRoutes: string[] = [];
+  ignoreI18nModifiers: boolean = false;
 
   updateOptions(options: ModuleOptions & CustomNuxtConfigOptions) {
     if (options.plugin != null) this.plugin = options.plugin;
@@ -64,6 +65,9 @@ class ModuleOptionsStore {
     }
     if (options.ignoreRoutes) {
       this.ignoreRoutes = options.ignoreRoutes;
+    }
+    if (options.ignoreI18nModifier) {
+      this.ignoreI18nModifiers = options.ignoreI18nModifier;
     }
 
     if (options.isDocumentDriven) {

--- a/src/core/parser/i18n.modifiers.ts
+++ b/src/core/parser/i18n.modifiers.ts
@@ -19,8 +19,8 @@ export function is18Sibling(source: RoutePathsDecl[], route: NuxtPage) {
 }
 
 export function modifyRoutePrefixDefaultIfI18n(route: NuxtPage) {
-  const { i18n, i18nOptions, i18nLocales } = moduleOptionStore;
-  if (i18n && i18nOptions && route.name) {
+  const { i18n, i18nOptions, i18nLocales, ignoreI18nModifiers } = moduleOptionStore;
+  if (i18n && i18nOptions && route.name && !ignoreI18nModifiers) {
     const separator = i18nOptions?.routesNameSeparator ?? '___';
     const i18LocalesRecognizer = i18nLocales
       ?.map((m) => m.replace(specialCharacterRegxp, '\\$&'))

--- a/src/types/config.types.ts
+++ b/src/types/config.types.ts
@@ -33,6 +33,11 @@ export interface ModuleOptions {
    * Ex: 404 routes or catchAll routes
    */
   ignoreRoutes?: string[];
+  /**
+   * Ignores i18n modifiers when generating typed routes
+   * @default false
+   */
+  ignoreI18nModifier?: boolean;
 }
 
 export interface StrictOptions {


### PR DESCRIPTION
# Description
This PR solves the issue #149, where router dependent functions such as `localePath` or `nuxtLinkLocale` would break if i18n was on with the strategy `prefix_and_default`, the bug might occur with other strategies, this has not been tested for the moment.

An option has been added `ignoreI18nModifiers` set by default to false to assure backwards compatibility, setting the option to true will prevent the generator from changing the routes names.

```javascript
nuxtTypedRouter: {
   ignoreI18nModifiers: true //default false
}
```

I haven't found any functionality that has been broken from this change yet