### PR TITLE
fix: (type) uses standard module augmentation which vue & nuxt core t…

### DIFF
--- a/src/core/output/generators/files/__typed-router.d.file.ts
+++ b/src/core/output/generators/files/__typed-router.d.file.ts
@@ -67,20 +67,6 @@ export function createTypedRouterDefinitionFile(): string {
       $props: TypedNuxtLinkProps<T, P, E>;
     };
 
-    declare module '@vue/runtime-core' {
-      interface GlobalComponents {
-        NuxtLink: TypedNuxtLink;
-        ${returnIfTrue(i18n, ` NuxtLinkLocale: TypedNuxtLinkLocale;`)}
-      }
-    }
-
-    declare module '@vue/runtime-dom' {
-      interface GlobalComponents {
-        NuxtLink: TypedNuxtLink;
-        ${returnIfTrue(i18n, ` NuxtLinkLocale: TypedNuxtLinkLocale;`)}
-      }
-    }
-
     declare module 'vue' {
       interface GlobalComponents {
         NuxtLink: TypedNuxtLink;


### PR DESCRIPTION
Uses standard module augmentation which vue & nuxt core teams recommends to avoid breaking module augmentation. Current style is outdated

Relevant links:
https://github.com/nuxt/nuxt/pull/28446
https://vuejs.org/guide/typescript/options-api.html#augmenting-global-properties