### PR TITLE
feat: create disablePrettier module option

### DIFF
--- a/docs/content/1.guide/1.configuration.md
+++ b/docs/content/1.guide/1.configuration.md
@@ -43,6 +43,11 @@ export interface ModuleOptions {
    * @default true
    */
   experimentalRemoveNuxtDefs?: boolean;
+  /**
+   * Disable prettier formatter
+   * @default false
+   */
+  disablePrettier?: boolean;
 }
 
 ```

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -9,6 +9,7 @@ export default defineNuxtConfig({
   nuxtTypedRouter: {
     plugin: true,
     pathCheck: true,
+    disablePrettier: false,
     removeNuxtDefs: true,
     ignoreRoutes: ['[...404].vue'],
   },

--- a/src/core/config/moduleOptions.ts
+++ b/src/core/config/moduleOptions.ts
@@ -17,6 +17,7 @@ class ModuleOptionsStore {
   plugin: boolean = false;
   strict: boolean | StrictOptions = false;
   pathCheck: boolean = true;
+  disablePrettier: boolean = false;
   autoImport: boolean = false;
   rootDir: string = '';
   buildDir: string = '';

--- a/src/core/fs/writeFile.ts
+++ b/src/core/fs/writeFile.ts
@@ -21,12 +21,12 @@ export async function processPathAndWriteFile({
   outDir,
 }: ProcessPathAndWriteFileArgs): Promise<void> {
   try {
-    const { rootDir } = moduleOptionStore;
+    const { rootDir, disablePrettier } = moduleOptionStore;
 
     const finalOutDir = outDir ?? `.nuxt/typed-router`;
     const processedOutDir = resolve(rootDir, finalOutDir);
     const outputFile = resolve(process.cwd(), `${processedOutDir}/${fileName}`);
-    const formatedContent = await formatOutputWithPrettier(content);
+    const formatedContent = disablePrettier ? content : await formatOutputWithPrettier(content);
 
     if (fs.existsSync(outputFile)) {
       await writeFile(outputFile, formatedContent);

--- a/src/module.ts
+++ b/src/module.ts
@@ -17,6 +17,7 @@ export default defineNuxtModule<ModuleOptions>({
     plugin: false,
     strict: false,
     pathCheck: true,
+    disablePrettier: false,
     removeNuxtDefs: true,
     ignoreRoutes: [],
   },


### PR DESCRIPTION
I've noticed that sometimes I got

```
ERROR  Maximum call stack size exceeded                                                       12:52:40 PM

  at callPluginPrintFunction (node_modules/.pnpm/prettier@3.3.3/node_modules/prettier/index.mjs:20861:33)
  at mainPrintInternal (node_modules/.pnpm/prettier@3.3.3/node_modules/prettier/index.mjs:20854:18)
  at mainPrint (node_modules/.pnpm/prettier@3.3.3/node_modules/prettier/index.mjs:20837:14)
  at node_modules/.pnpm/prettier@3.3.3/node_modules/prettier/index.mjs:19373:23
  at AstPath.each (node_modules/.pnpm/prettier@3.3.3/node_modules/prettier/index.mjs:19360:9)
  at AstPath.map (node_modules/.pnpm/prettier@3.3.3/node_modules/prettier/index.mjs:19372:10)
  at Pt (node_modules/.pnpm/prettier@3.3.3/node_modules/prettier/plugins/estree.mjs:36:48503)
  at ka (node_modules/.pnpm/prettier@3.3.3/node_modules/prettier/plugins/estree.mjs:36:82156)
  at Hl (node_modules/.pnpm/prettier@3.3.3/node_modules/prettier/plugins/estree.mjs:36:85139)
  at Object.$l (node_modules/.pnpm/prettier@3.3.3/node_modules/prettier/plugins/estree.mjs:36:85547)
```

So, I search on my entire project and I found in your Nuxt Module the follow line:
```javascript
const formatedContent = await formatOutputWithPrettier(content);
```

I add some debugs and I finally confirm that sometimes the code above is creating the maximum call stack size exceeded error. So, I decide to fork it and add a module option to disable the code formatter.

I keep the default as false to don't create unexpected behavior to other people.